### PR TITLE
Remove publish_branch from gh-pages deployment

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -64,4 +64,3 @@ jobs:
           commit_message: ${{ github.event.head_commit.message }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build/splittheloot
-          publish_branch: master


### PR DESCRIPTION
# Deployment to GH Pages

Working on getting GitHub Pages Deployment working
